### PR TITLE
fix(core): Add VgPlayerComponent to CoreModule exports

### DIFF
--- a/libs/ngx-videogular/core/src/lib/core.module.ts
+++ b/libs/ngx-videogular/core/src/lib/core.module.ts
@@ -28,6 +28,6 @@ const directives = [
   imports: [CommonModule],
   providers: [...services],
   declarations: [...directives, VgPlayerComponent],
-  exports: [...directives]
+  exports: [...directives, VgPlayerComponent]
 })
 export class CoreModule {}


### PR DESCRIPTION
Fix bug: 'Unknown element vg-player' due to VgPlayerComponent not being exported in the CoreModule file