### PR TITLE
fix(lib): peerDependencies now allow for angular 8, 9, 10 - all minor…

### DIFF
--- a/libs/ngx-videogular/package.json
+++ b/libs/ngx-videogular/package.json
@@ -8,15 +8,15 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@angular/common": ">=8.0.0 <10.0.3",
-    "@angular/core": ">=8.0.0 <10.0.3",
-    "@angular/platform-browser-dynamic": ">=8.0.0 <10.0.3",
+    "@angular/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+    "@angular/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
+    "@angular/platform-browser-dynamic": "^8.0.0 || ^9.0.0 || ^10.0.0",
     "core-js": "^2.5.4",
     "rxjs": "~6.5.4",
     "zone.js": "^0.10.2"
   },
   "dependencies": {
-    "tslib": "^1.11.1"
+    "tslib": "^1.11.1 || ^2.0.0"
   },
   "sideEffects": false,
   "private": false,


### PR DESCRIPTION
… and bugfix

#21

### Description
Allow for Angular 8, 9, 10 and all their minor and bugfix versions

### Checklist
Please, check that you have been followed next steps:

- I've read the (contributing)[https://github.com/videogular/ngx-videogular/blob/master/CONTRIBUTING.md] guidelines
- Code compiles correctly (run `npm start`) (check)
- Created tests (if necessary) (not necessary)
- All tests passing (run `npm test`) (check)
- Extended the README / documentation (if necessary) (not necessary)