### PR TITLE
fix(lib): allow for minor rxjs versions like 6.6.x

### DIFF
--- a/libs/ngx-videogular/package.json
+++ b/libs/ngx-videogular/package.json
@@ -12,7 +12,7 @@
     "@angular/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
     "@angular/platform-browser-dynamic": "^8.0.0 || ^9.0.0 || ^10.0.0",
     "core-js": "^2.5.4",
-    "rxjs": "~6.5.4",
+    "rxjs": "^6.5.4",
     "zone.js": "^0.10.2"
   },
   "dependencies": {


### PR DESCRIPTION
aligns with angular peer dependency

### Description

ng update throws an error while updating to rxjs 6.6.x:
`Package "ngx-videogular" has an incompatible peer dependency to "rxjs" (requires "~6.5.4", would install "6.6.2").`

as rxjs follows semantic versioning, minor versions may only introduce features, never breaking changes.

this change allows for rxjs 6.6 as dependency