### PR TITLE
fix(streaming): Removed setLogToBrowserConsole call in Dash directive

### DIFF
--- a/libs/ngx-videogular/streaming/src/lib/directives/vg-dash/vg-dash.directive.ts
+++ b/libs/ngx-videogular/streaming/src/lib/directives/vg-dash/vg-dash.directive.ts
@@ -90,7 +90,7 @@ export class VgDashDirective implements OnInit, OnChanges, OnDestroy {
       }
 
       this.dash = dashjs.MediaPlayer().create();
-      this.dash.getDebug().setLogToBrowserConsole(false);
+      this.dash.updateSettings({ 'debug': { 'logLevel': dashjs.Debug.LOG_LEVEL_NONE } });
       this.dash.initialize(this.ref.nativeElement);
       this.dash.setAutoPlay(false);
 

--- a/libs/ngx-videogular/streaming/src/lib/directives/vg-dash/vg-dash.directive.ts
+++ b/libs/ngx-videogular/streaming/src/lib/directives/vg-dash/vg-dash.directive.ts
@@ -21,6 +21,7 @@ declare let dashjs: {
     (): { (): any; new (): any; create: { (): any; new (): any } };
     events: { STREAM_INITIALIZED: any };
   };
+  Debug: { LOG_LEVEL_NONE: any };
 };
 
 @Directive({


### PR DESCRIPTION
Fixes issue with a call to non-existing method 

### Description
Dash.js 3.0.0 removes setLogToBrowserConsole() method but vgDash directive still contains a reference to it. When trying to use DASH streaming it causes whole player to crash and prevents video playback.
Reference:
https://github.com/Dash-Industry-Forum/dash.js/issues/3018
