### PR TITLE
add attribute vg-overlay-play[vgSkipIfControlsHidden]

### DIFF
--- a/libs/ngx-videogular/controls/src/lib/components/vg-controls/vg-controls.component.ts
+++ b/libs/ngx-videogular/controls/src/lib/components/vg-controls/vg-controls.component.ts
@@ -53,6 +53,7 @@ export class VgControlsComponent implements OnInit, AfterViewInit, OnDestroy {
 
   mouseMove$: Observable<any>;
   touchStart$: Observable<any>;
+  mouseClick$: Observable<any>;
 
   subscriptions: Subscription[] = [];
   // @ts-ignore
@@ -70,6 +71,9 @@ export class VgControlsComponent implements OnInit, AfterViewInit, OnDestroy {
 
     this.touchStart$ = fromEvent(this.API.videogularElement, 'touchstart');
     this.subscriptions.push(this.touchStart$.subscribe(this.show.bind(this)));
+
+    this.mouseClick$ = fromEvent(this.API.videogularElement, 'click');
+    this.subscriptions.push(this.mouseClick$.subscribe(this.show.bind(this)));
 
     if (this.API.isPlayerReady) {
       this.onPlayerReady();

--- a/libs/ngx-videogular/overlay-play/src/lib/vg-overlay-play.component.spec.ts
+++ b/libs/ngx-videogular/overlay-play/src/lib/vg-overlay-play.component.spec.ts
@@ -20,7 +20,7 @@ describe('Videogular Player', () => {
 
     controlsHidden = {
       isHidden: {
-        subscribe: () => {},
+        subscribe: () => { },
       },
     } as VgControlsHiddenService;
 
@@ -48,8 +48,8 @@ describe('Videogular Player', () => {
   describe('onClick', () => {
     beforeEach(() => {
       overlayPlay.target = {
-        play: () => {},
-        pause: () => {},
+        play: () => { },
+        pause: () => { },
       };
     });
 

--- a/libs/ngx-videogular/overlay-play/src/lib/vg-overlay-play.component.ts
+++ b/libs/ngx-videogular/overlay-play/src/lib/vg-overlay-play.component.ts
@@ -73,6 +73,7 @@ import { VgApiService, VgFullscreenApiService, VgControlsHiddenService, VgStates
 })
 export class VgOverlayPlayComponent implements OnInit, OnDestroy {
   @Input() vgFor: string;
+  @Input() vgSkipOnControlsHidden = false;
   elem: HTMLElement;
   target: any;
 
@@ -135,6 +136,10 @@ export class VgOverlayPlayComponent implements OnInit, OnDestroy {
 
   @HostListener('click')
   onClick() {
+    if (this.vgSkipOnControlsHidden && this.areControlsHidden) {
+      return;
+    }
+
     const state = this.getState();
 
     switch (state) {

--- a/libs/ngx-videogular/overlay-play/src/lib/vg-overlay-play.component.ts
+++ b/libs/ngx-videogular/overlay-play/src/lib/vg-overlay-play.component.ts
@@ -73,12 +73,14 @@ import { VgApiService, VgFullscreenApiService, VgControlsHiddenService, VgStates
 })
 export class VgOverlayPlayComponent implements OnInit, OnDestroy {
   @Input() vgFor: string;
-  @Input() vgSkipOnControlsHidden = false;
+  @Input() vgSkipIfControlsHidden = false;
+  @Input() vgSkipIfControlsHiddenDelay = 0.5;
   elem: HTMLElement;
   target: any;
 
   isNativeFullscreen = false;
   areControlsHidden = false;
+  areControlsHiddenChangeTime: number = 0;
 
   subscriptions: Subscription[] = [];
 
@@ -131,12 +133,16 @@ export class VgOverlayPlayComponent implements OnInit, OnDestroy {
   }
 
   onHideControls(hidden: boolean) {
+    if (this.vgSkipIfControlsHidden && this.areControlsHidden != hidden) {
+      this.areControlsHiddenChangeTime = Date.now();
+    }
     this.areControlsHidden = hidden;
+
   }
 
   @HostListener('click')
   onClick() {
-    if (this.vgSkipOnControlsHidden && this.areControlsHidden) {
+    if (this.vgSkipIfControlsHidden && (this.areControlsHidden || (Date.now() - this.areControlsHiddenChangeTime) < this.vgSkipIfControlsHiddenDelay * 1000)) {
       return;
     }
 


### PR DESCRIPTION
### Description
Hi, first of all thanks for this great library. This PR is to improve the behaviour of `vg-overlay-play` by adding new attribute flag `[vgSkipIfControlsHidden]`. It is extremely useful on mobile device when click and `vg-controls[vgAutohide]="true"`. first click it appears the controls and second click pauses video. It match youtube behaviour except youtube player has a small bug.

I will add some documentation and tests to cover this case.