### PR TITLE
fix isiOSDevice function for IPad

### DIFF
--- a/libs/ngx-videogular/core/src/lib/services/vg-utils/vg-utils.service.ts
+++ b/libs/ngx-videogular/core/src/lib/services/vg-utils/vg-utils.service.ts
@@ -41,8 +41,17 @@ export class VgUtilsService {
 
   static isiOSDevice() {
     return (
-      navigator.userAgent.match(/ip(hone|ad|od)/i) &&
+      (navigator.userAgent.match(/ip(hone|ad|od)/i) || 
+      VgUtilsService.isIpadOS()) &&
       !navigator.userAgent.match(/(iemobile)[\/\s]?([\w\.]*)/i)
+    );
+  }
+
+  static isIpadOS() {
+    return (
+      navigator.maxTouchPoints && 
+      navigator.maxTouchPoints > 2 &&
+      /MacIntel/.test(navigator.platform)
     );
   }
 


### PR DESCRIPTION
Should fix [Fullscreen mode on Ipad doesn't work #67](https://github.com/videogular/ngx-videogular/issues/67)