### PR TITLE
fix(vg-scrub-bar): Scrub bar was glitching on mobile

### DIFF
--- a/libs/ngx-videogular/controls/src/lib/components/vg-scrub-bar/vg-scrub-bar.component.spec.ts
+++ b/libs/ngx-videogular/controls/src/lib/components/vg-scrub-bar/vg-scrub-bar.component.spec.ts
@@ -158,7 +158,6 @@ describe('Scrub bar', () => {
 
       scrubBar.onTouchStartScrubBar({ touches: [{ pageX: 20 }] });
 
-      expect(api.seekTime).toHaveBeenCalledWith(10, true);
       expect(api.pause).toHaveBeenCalledTimes(0);
 
       scrubBar.vgSlider = true;
@@ -166,7 +165,6 @@ describe('Scrub bar', () => {
 
       scrubBar.onTouchStartScrubBar({ touches: [{ pageX: 20 }] });
 
-      expect(api.seekTime).toHaveBeenCalledTimes(1);
       expect(api.pause).toHaveBeenCalledTimes(1);
     });
   });

--- a/libs/ngx-videogular/controls/src/lib/components/vg-scrub-bar/vg-scrub-bar.component.ts
+++ b/libs/ngx-videogular/controls/src/lib/components/vg-scrub-bar/vg-scrub-bar.component.ts
@@ -145,14 +145,16 @@ export class VgScrubBarComponent implements OnInit, OnDestroy {
     }
   }
 
-  protected seekEnd(offset: number) {
+  protected seekEnd(offset: number | false) {
     this.isSeeking = false;
     if (this.target.canPlay) {
-      const percentage = Math.max(
-        Math.min((offset * 100) / this.elem.scrollWidth, 99.9),
-        0
-      );
-      this.target.seekTime(percentage, true);
+      if (offset !== false) {
+        const percentage = Math.max(
+          Math.min((offset * 100) / this.elem.scrollWidth, 99.9),
+          0
+        );
+        this.target.seekTime(percentage, true);
+      }
       if (this.wasPlaying) {
         this.wasPlaying = false;
         this.target.play();
@@ -210,11 +212,11 @@ export class VgScrubBarComponent implements OnInit, OnDestroy {
   }
 
   @HostListener('touchstart', ['$event'])
-  onTouchStartScrubBar($event: any) {
+  onTouchStartScrubBar(_$event: any) {
     if (this.target) {
       if (!this.target.isLive) {
         if (!this.vgSlider) {
-          this.seekEnd(this.getTouchOffset($event));
+          this.seekEnd(false);
         } else {
           this.seekStart();
         }


### PR DESCRIPTION
### Description
In response to my issue #101, the scrub bar was unreliable on iOS when lifting your finger. I fixed the scrub bar in probably the most low effort solution I could come up with. I tested it on iOS Chrome, iOS Safari, and Windows Chrome.

I fixed it by: Removed the scrub bar changes from happening on touchend event.

Since there are events for touchstart and touchmove, having a touchend event that also makes changes to the scrub bar percent is not needed.

### Checklist
Please, check that you have been followed next steps:

- I've read the (contributing)[https://github.com/videogular/ngx-videogular/blob/master/CONTRIBUTING.md] guidelines
- Code compiles correctly (run `npm start`)
- Created tests (if necessary)
- All tests passing (run `npm test`)
- Extended the README / documentation (if necessary)

*Note: I didn't run `npm run commit`. Also I had to remove a test, however this is just a simple result of the changes made and not an error.*