### PR TITLE
fix(player): add descendants option in contentchildren

### DIFF
--- a/libs/ngx-videogular/core/src/lib/components/vg-player/vg-player.component.ts
+++ b/libs/ngx-videogular/core/src/lib/components/vg-player/vg-player.component.ts
@@ -55,7 +55,7 @@ export class VgPlayerComponent implements AfterContentInit, OnDestroy {
   @Output() onPlayerReady: EventEmitter<VgApiService> = new EventEmitter<VgApiService>();
   @Output() onMediaReady: EventEmitter<any> = new EventEmitter();
 
-  @ContentChildren(VgMediaDirective) medias: QueryList<VgMediaDirective>;
+  @ContentChildren(VgMediaDirective, { descendants: true }) medias: QueryList<VgMediaDirective>;
 
   subscriptions: Subscription[] = [];
 


### PR DESCRIPTION
### Description
This option is required in new Angular version, otherwise it doesn't know how to collect nested children in ng-content.

### Checklist
Please, check that you have been followed next steps:

- I've read the (contributing)[https://github.com/videogular/ngx-videogular/blob/master/CONTRIBUTING.md] guidelines
- Code compiles correctly (run `npm start`)
- Created tests (if necessary)
- All tests passing (run `npm test`)
- Extended the README / documentation (if necessary)