### PR TITLE
#138 Fix aria-label to not contain "button" for elements with role="button".

### DIFF
--- a/libs/ngx-videogular/controls/src/lib/components/vg-fullscreen/vg-fullscreen.component.ts
+++ b/libs/ngx-videogular/controls/src/lib/components/vg-fullscreen/vg-fullscreen.component.ts
@@ -18,7 +18,7 @@ import { VgApiService, VgFullscreenApiService } from '@videogular/ngx-videogular
     [class.vg-icon-fullscreen_exit]="isFullscreen"
     tabindex="0"
     role="button"
-    aria-label="fullscreen button"
+    aria-label="fullscreen"
     [attr.aria-valuetext]="ariaValue"
   ></div>`,
   styles: [

--- a/libs/ngx-videogular/controls/src/lib/components/vg-mute/vg-mute.component.ts
+++ b/libs/ngx-videogular/controls/src/lib/components/vg-mute/vg-mute.component.ts
@@ -21,7 +21,7 @@ import { VgApiService } from '@videogular/ngx-videogular/core';
     [class.vg-icon-volume_off]="getVolume() === 0"
     tabindex="0"
     role="button"
-    aria-label="mute button"
+    aria-label="mute"
     [attr.aria-valuetext]="ariaValue"
   ></div>`,
   styles: [

--- a/libs/ngx-videogular/controls/src/lib/components/vg-playback-button/vg-playback-button.component.ts
+++ b/libs/ngx-videogular/controls/src/lib/components/vg-playback-button/vg-playback-button.component.ts
@@ -18,7 +18,7 @@ import { VgApiService } from '@videogular/ngx-videogular/core';
     class="button"
     tabindex="0"
     role="button"
-    aria-label="playback speed button"
+    aria-label="playback speed"
     [attr.aria-valuetext]="ariaValue"
   >
     {{ getPlaybackRate() }}x


### PR DESCRIPTION
### Description
[Fix]
This prevents screen readers to read e.g. "Playback speed button button". It now properly reads "Playback speed button".

### Checklist
Please, check that you have been followed next steps:

- I've read the (contributing)[https://github.com/videogular/ngx-videogular/blob/master/CONTRIBUTING.md] guidelines
- Code compiles correctly (run `npm start`)
- Created tests (if necessary)
- All tests passing (run `npm test`)
- Extended the README / documentation (if necessary)